### PR TITLE
Implemented `meta-suffix` run config parameter

### DIFF
--- a/bearysta/run.py
+++ b/bearysta/run.py
@@ -25,6 +25,9 @@ def run_benchmark(env, config, run_path='runs', run_id=None, commands=None,
     with open(config) as f:
         bench = yaml.load(f)
 
+    # Specify suffix for meta file of run configuration. E.g. '.csv' if $outprefix.csv is the consumable command output.
+    meta_suff = bench.get('meta-suffix', '.out')
+
     # Make sure we at least have an empty vars list
     if 'variables' not in bench:
         bench['variables'] = {}
@@ -122,7 +125,7 @@ def run_benchmark(env, config, run_path='runs', run_id=None, commands=None,
                 fd.write(data)
 
             # output the environment we created as well.
-            with open(output_prefix + '.out.meta', 'w') as fd:
+            with open(output_prefix + meta_suff + '.meta', 'w') as fd:
                 yaml.dump(arg_run, fd)
 
 class CurrentEnv:
@@ -157,7 +160,7 @@ def main():
     import argparse
     parser = argparse.ArgumentParser()
     parser.add_argument('--benchmarks', '-b', default=None, nargs='+',
-                        help='Run specified benchmarks names only')
+                        help='Run specified benchmark names only')
     parser.add_argument('--commands', '-c', default=None, nargs='+',
                         help='Run these benchmark commands only')
     parser.add_argument('--bench-path', default=None, nargs='+',

--- a/doc/RUNNER.md
+++ b/doc/RUNNER.md
@@ -104,7 +104,9 @@ in `$CONDA_PREFIX/benchmarks/`. Each config defines global environment variables
 and local variables. Command lines can thus contain parameter substitution.
 
 We use the Cartesian product of all variables defined for a particular command (where local variables override
-global ones) to run it with all combinations of variables.
+global ones) to run it with all combinations of variables. The command output is captured in "$outprefix.out"
+file while the set of current variables for the given run is stored in "$outprefix.out.meta" file (it can be
+overrided via `meta-suffix` configuration.
 
 For example, for ibench_native, one may write:
 
@@ -112,6 +114,8 @@ For example, for ibench_native, one may write:
 variables:
   bench: [det_native, dot_native, inv_native, lu_native]
   size: [test, tiny, small, large]
+
+meta-suffix: .out
 
 commands:
   ibench_native: IBENCH_PLUGINS=ibench_native python -m ibench run --benchmarks $bench --size $size --runs 10
@@ -140,6 +144,7 @@ automatically be overridden by the benchmarking system.
 
 - `env_name`: the name given in the environment configuration.
 - `hostname`: the name of the machine, as given by `platform.node()`
+- `outprefix`: path and name of the the command's output capture file
 
 ### Config overrides
 A user can override any aspect of benchmark configurations without directly editing any, by simply creating override configurations inside the `overrides/` directory, ending in `.yaml`. For example, the following could work to disable sequential mode for scikit-learn python benchmarks, and restrict the kmeans size to the given one:


### PR DESCRIPTION
Use case: a command generates ".csv" files (configurable), which can be processed by the aggregator directly instead of reading and filtering out content from ".out" files. Thus the run configuration has to have ".csv.meta" extension. This new parameter allows it by adding the following string to run recipe:
```
# roofline script creates .csv file, thus meta info goes into $outprefix.csv.meta
meta-suffix: ".csv"
```
