### PR TITLE
fix relative import .run for py39

### DIFF
--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -326,7 +326,7 @@ class CondaEnv:
                 found_pip = True
 
         if found_pip:
-            info_cmd = ['pip', 'freeze', '--quiet', '--local']
+            info_cmd = ['pip', 'list', '--format=freeze', '--local']
             pip_list = self.call_stdout(info_cmd).split()
             pip_list = [s.split('==') for s in pip_list]
 

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -10,7 +10,7 @@ import time
 import re
 import platform
 
-from .run import run_benchmark, yaml
+from run import run_benchmark, yaml
 
 
 def setup_environments(env_metas, **kwargs):

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -98,7 +98,7 @@ def main():
             print('#### Running', progress_bench)
             # Run benchmark
             apply_overrides = [o for o in overrides if (bname in o['override']['benchmark'] and env.name in o['override']['envs'])]
-            run.run_benchmark(env.name, f, run_id=args.run_id, commands=args.commands,
+            run.run_benchmark(env, f, run_id=args.run_id, commands=args.commands,
                           run_path=args.run_path, overrides=apply_overrides,
                           suite=bname, dry_run=args.dry_run, progress=progress_bench)
     return args.dry_run  # mark the build failed in CI because no meaningful result was produced

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -1,25 +1,17 @@
 import glob
 import os
-import shlex
-from copy import deepcopy
-from collections import namedtuple
-from functools import reduce
-import itertools
-from subprocess import PIPE
 import time
-import re
-import platform
 
-from run import run_benchmark, yaml
+import run
 
 
 def setup_environments(env_metas, **kwargs):
-    from .conda_env import CondaEnv
+    import conda_env
     envs = []
     nenvs = len(env_metas)
     for i, f in enumerate(env_metas):
         print('# Creating environment "{}" ({}/{})'.format(f, i+1, nenvs))
-        envs.append(CondaEnv(f, **kwargs))
+        envs.append(conda_env.CondaEnv(f, **kwargs))
 
     return envs
 
@@ -72,7 +64,7 @@ def main():
     overrides = []
     for f in args.overrides_path:
         with open(f) as fd:
-            o = yaml.load(fd)
+            o = run.yaml.load(fd)
         if 'override' not in o:
             print('# WARNING: ignoring invalid override at {}'.format(f))
             continue
@@ -106,7 +98,7 @@ def main():
             print('#### Running', progress_bench)
             # Run benchmark
             apply_overrides = [o for o in overrides if (bname in o['override']['benchmark'] and env.name in o['override']['envs'])]
-            run_benchmark(env.name, f, run_id=args.run_id, commands=args.commands,
+            run.run_benchmark(env.name, f, run_id=args.run_id, commands=args.commands,
                           run_path=args.run_path, overrides=apply_overrides,
                           suite=bname, dry_run=args.dry_run, progress=progress_bench)
     return args.dry_run  # mark the build failed in CI because no meaningful result was produced


### PR DESCRIPTION
Relative import works a bit differently in recent py versions. It is fixed now.