### PR TITLE
Mutiple improvements

### DIFF
--- a/bearysta/aggregate.py
+++ b/bearysta/aggregate.py
@@ -836,7 +836,7 @@ class Benchmark:
             # TODO - there has to be a better way of grabbing the raw config
             package_files = []
             for raw_config_glob in self.config['input']['config']:
-                raw_config_path = re.sub(r'\/config\/.*\.yml', f'/config/{raw_config_glob}', self.config_path)
+                raw_config_path = os.path.join(os.path.dirname(self.config_path),raw_config_glob)
                 raw_config = yaml.load(open(raw_config_path))
                 output_glob = raw_config['input']['packages_path']
                 package_files.extend(glob.glob(output_glob))

--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -130,6 +130,7 @@ class CondaEnv:
                 channels.extend(config['channels'])
                 self.install_packages(config['benchmarks'], installer='conda',
                                     no_deps=True, copy=True, channels=channels)
+                self.benchmarks = config['benchmarks']
 
         if not skip_listing:
             self.packages = self.get_packages()

--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -68,7 +68,7 @@ class CondaEnv:
             with open(fn) as f:
                 config = yaml.load(f)
                 self.name = config['name']
-                # self.benchmarks = config['benchmarks']
+                self.benchmarks = config['benchmarks']
 
         # Deduce prefix from the env config if it wasn't given.
         if prefix is None:

--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -26,7 +26,7 @@ class CondaEnv:
 
 
     def __init__(self, fn=None, prefix=None, clobber=False,
-                 skip_listing=False, existing_env=False):
+                 skip_listing=False, existing_env=False, run_path='runs'):
         '''Create or reference an existing environment with the given prefix.
         If an environment already exists at the given or implied prefix,
         the specified packages will be installed.
@@ -47,7 +47,7 @@ class CondaEnv:
             use an existing environment at the given prefix.
         prefix : str, optional
             The prefix for the conda environment. If not specified, we will
-            use ./envs/<name>.
+            use <run_path>/envs/<name>.
         clobber : bool, optional (default False)
             if True, destroy the current environment if any exists.
             This prevents weird things like updating certain packages
@@ -57,6 +57,9 @@ class CondaEnv:
         existing_env: bool, optional (default False)
             if True, use existing env. 
             Do not install anything, but just execute benchmarks
+        run_path: (Default ./runs)
+            Directory where conda envs to be created, i.e. <run_path>/envs/
+            
         '''
 
         if fn is None and prefix is None:
@@ -71,7 +74,7 @@ class CondaEnv:
         if prefix is None:
             self.prefix = os.path.join(os.getcwd(), 'envs', self.name)
         else:
-            self.prefix = prefix
+            self.prefix = os.path.join(run_path, 'envs', self.name)
 
         self.base_prefix = self.get_base_prefix()
 

--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -200,7 +200,7 @@ class CondaEnv:
 
     def _get_source_cmd(self):
 
-        return ['.', os.path.join(self.get_base_prefix(), 'etc', 'profile.d', 'conda.sh')]
+        return ['source', os.path.join(self.get_base_prefix(), 'bin', 'activate')]
 
 
     def _get_activate_cmd(self, prefix=None):

--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -200,7 +200,7 @@ class CondaEnv:
 
     def _get_source_cmd(self):
 
-        return ['source', os.path.join(self.get_base_prefix(), 'bin', 'activate')]
+        return ['.', os.path.join(self.get_base_prefix(), 'bin', 'activate')]
 
 
     def _get_activate_cmd(self, prefix=None):

--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -2,7 +2,6 @@ from subprocess import Popen, PIPE
 import os
 import json
 import platform
-import shutil # python 3.3+
 import shlex # python 3.3+ for shlex.quote
 import tempfile
 import re
@@ -57,7 +56,7 @@ class CondaEnv:
         existing_env: bool, optional (default False)
             if True, use existing env. 
             Do not install anything, but just execute benchmarks
-        run_path: (Default ./runs)
+        run_path: (Default runs)
             Directory where conda envs to be created, i.e. <run_path>/envs/
             
         '''
@@ -72,9 +71,9 @@ class CondaEnv:
 
         # Deduce prefix from the env config if it wasn't given.
         if prefix is None:
-            self.prefix = os.path.join(os.getcwd(), 'envs', self.name)
+            self.prefix = os.path.join(os.path.abspath(run_path), 'envs', self.name)
         else:
-            self.prefix = os.path.join(run_path, 'envs', self.name)
+            self.prefix = prefix
 
         self.base_prefix = self.get_base_prefix()
 

--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -199,8 +199,8 @@ class CondaEnv:
 
 
     def _get_source_cmd(self):
-
-        return ['.', os.path.join(self.get_base_prefix(), 'bin', 'activate')]
+        # conda activate scripts are bash syntax
+        return ['/bin/bash', 'source', os.path.join(self.get_base_prefix(), 'bin', 'activate')]
 
 
     def _get_activate_cmd(self, prefix=None):

--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -68,7 +68,7 @@ class CondaEnv:
             with open(fn) as f:
                 config = yaml.load(f)
                 self.name = config['name']
-                self.benchmarks = config['benchmarks']
+                # self.benchmarks = config['benchmarks']
 
         # Deduce prefix from the env config if it wasn't given.
         if prefix is None:
@@ -122,15 +122,15 @@ class CondaEnv:
                 self.packages = self.get_packages()
 
 
-            # Install benchmarks if specified in the config.
-            if 'benchmarks' in config:
-                channels = config.get('benchmark-channels', [])
-                # FIXME GH-100 conda still runs the solver here, even though we
-                # ask for --no-deps, so we prevent it from failing by adding
-                # our channels...
-                channels.extend(config['channels'])
-                self.install_packages(config['benchmarks'], installer='conda',
-                                    no_deps=True, copy=True, channels=channels)
+            # # Install benchmarks if specified in the config.
+            # if 'benchmarks' in config:
+            #     channels = config.get('benchmark-channels', [])
+            #     # FIXME GH-100 conda still runs the solver here, even though we
+            #     # ask for --no-deps, so we prevent it from failing by adding
+            #     # our channels...
+            #     channels.extend(config['channels'])
+            #     self.install_packages(config['benchmarks'], installer='conda',
+            #                         no_deps=True, copy=True, channels=channels)
 
         if not skip_listing:
             self.packages = self.get_packages()

--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -355,10 +355,6 @@ class CondaEnv:
                 packages[name.lower()] = {'name': name, 'version': ver, 'installer': 'pip'}
 
         return packages
-    
-    def dump_pkg_list_to_yaml(self, filename):
-        # output conda packages
-        with open(filename, 'w') as fd:
-            yaml.dump(self.packages, fd)
+
 
 

--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -200,7 +200,7 @@ class CondaEnv:
 
     def _get_source_cmd(self):
         # conda activate scripts are bash syntax
-        return ['/bin/bash', 'source', os.path.join(self.get_base_prefix(), 'bin', 'activate')]
+        return ['source', os.path.join(self.get_base_prefix(), 'bin', 'activate')]
 
 
     def _get_activate_cmd(self, prefix=None):
@@ -251,7 +251,9 @@ class CondaEnv:
 
         if 'PATH' not in env:
             env['PATH'] = os.environ['PATH']
-        return Popen(activate_cmd, env=env, shell=True, **kwargs)
+
+        # when shell=True, it defaults to /bin/sh which is BAD
+        return Popen(activate_cmd, env=env, shell=True, executable='/bin/bash', **kwargs)
 
 
     def call_communicate(self, cmd, check=True, **kwargs):

--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -68,6 +68,7 @@ class CondaEnv:
             with open(fn) as f:
                 config = yaml.load(f)
                 self.name = config['name']
+                self.benchmarks = config['benchmarks']
 
         # Deduce prefix from the env config if it wasn't given.
         if prefix is None:
@@ -130,7 +131,6 @@ class CondaEnv:
                 channels.extend(config['channels'])
                 self.install_packages(config['benchmarks'], installer='conda',
                                     no_deps=True, copy=True, channels=channels)
-                self.benchmarks = config['benchmarks']
 
         if not skip_listing:
             self.packages = self.get_packages()

--- a/bearysta/conda_env.py
+++ b/bearysta/conda_env.py
@@ -355,5 +355,10 @@ class CondaEnv:
                 packages[name.lower()] = {'name': name, 'version': ver, 'installer': 'pip'}
 
         return packages
+    
+    def dump_pkg_list_to_yaml(self, filename):
+        # output conda packages
+        with open(filename, 'w') as fd:
+            yaml.dump(self.packages, fd)
 
 

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -98,7 +98,7 @@ def main():
             progress_bench = 'benchmark "{}" ({}/{}) via {}'.format(bname, j+1, nbenches, progress_env)
             print('#### Running', progress_bench)
             # Run benchmark
-            apply_overrides = [o for o in overrides['override'] if (bname in o['benchmark'] and env.name in o['envs'])]
+            apply_overrides = [o['override'] for o in overrides if (bname in o['override']['benchmark'] and env.name in o['override']['envs'])]
             run.run_benchmark(env, f, run_id=args.run_id, commands=args.commands,
                           run_path=args.run_path, overrides=apply_overrides,
                           suite=bname, dry_run=args.dry_run, progress=progress_bench)

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -58,7 +58,7 @@ def main():
     args = parser.parse_args()
 
     print('###### Preparing environments... ######\n')
-    env_kwargs = dict(clobber=args.clean, skip_listing=args.skip_package_listing, existing_env=args.use_existing_env, prefix=args.run_path)
+    env_kwargs = dict(clobber=args.clean, skip_listing=args.skip_package_listing, existing_env=args.use_existing_env, run_path=args.run_path)
 
     envs = setup_environments(args.env_path, **env_kwargs)
 

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -99,12 +99,6 @@ def main():
         for j, f in enumerate(benchmarks):
             bname = os.path.splitext(os.path.basename(f))[0]
             progress_bench = 'benchmark "{}" ({}/{}) via {}'.format(bname, j+1, nbenches, progress_env)
-
-            # dump env pkg list to yml file
-            evn_pkg_list_file = '{}/{}/{}/{}/{}_packages.yml'.format(args.run_path, args.run_id, bname,
-                                            env.name, env.name)
-            env.dump_pkg_list_to_yaml(evn_pkg_list_file)
-
             print('#### Running', progress_bench)
             # Run benchmark
             apply_overrides = [o for o in overrides if (bname in o['override']['benchmark'] and env.name in o['override']['envs'])]

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -71,11 +71,6 @@ def main():
             if 'override' not in o:
                 print('# WARNING: ignoring invalid override at {}'.format(f))
                 continue
-            for k, v in o['override'].items():
-                if type(v) is str:
-                    o['override'][k] = [v]
-
-            o['override']['envs'] = o['override'].get('envs', [e.name for e in envs])
             overrides.append(o)
 
     print('\n###### Running benchmarks... #######')
@@ -103,7 +98,7 @@ def main():
             progress_bench = 'benchmark "{}" ({}/{}) via {}'.format(bname, j+1, nbenches, progress_env)
             print('#### Running', progress_bench)
             # Run benchmark
-            apply_overrides = [o for o in overrides if (bname in o['override']['benchmark'] and env.name in o['override']['envs'])]
+            apply_overrides = [o for o in overrides['override'] if (bname in o['benchmark'] and env.name in o['envs'])]
             run.run_benchmark(env, f, run_id=args.run_id, commands=args.commands,
                           run_path=args.run_path, overrides=apply_overrides,
                           suite=bname, dry_run=args.dry_run, progress=progress_bench)

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -83,6 +83,7 @@ def main():
     for i, env in enumerate(envs):
         progress_env = 'environment "{}" ({}/{})'.format(env.name, i+1, nenvs)
         print('##### Selected', progress_env)
+
         # Get benchmark yamls
         if args.bench_path:
             benchmarks = glob.glob(os.path.join(os.path.abspath(args.bench_path), '*.yaml'))
@@ -98,6 +99,12 @@ def main():
         for j, f in enumerate(benchmarks):
             bname = os.path.splitext(os.path.basename(f))[0]
             progress_bench = 'benchmark "{}" ({}/{}) via {}'.format(bname, j+1, nbenches, progress_env)
+
+            # dump env pkg list to yml file
+            evn_pkg_list_file = '{}/{}/{}/{}/{}_packages.yml'.format(args.run_path, args.run_id, bname,
+                                            env.name, env.name)
+            env.dump_pkg_list_to_yaml(evn_pkg_list_file)
+
             print('#### Running', progress_bench)
             # Run benchmark
             apply_overrides = [o for o in overrides if (bname in o['override']['benchmark'] and env.name in o['override']['envs'])]

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -58,7 +58,7 @@ def main():
     args = parser.parse_args()
 
     print('###### Preparing environments... ######\n')
-    env_kwargs = dict(clobber=args.clean, skip_listing=args.skip_package_listing, existing_env=args.use_existing_env)
+    env_kwargs = dict(clobber=args.clean, skip_listing=args.skip_package_listing, existing_env=args.use_existing_env, prefix=args.run_path)
 
     envs = setup_environments(args.env_path, **env_kwargs)
 

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -23,8 +23,9 @@ def main():
     parser.add_argument('--clean', '-C', action='store_true', default=False,
                         help="Delete environments before installing packages")
     parser.add_argument('--use-existing-env', '-E', action='store_true', default=False,
-                        help="Do not modify environments, install nothing but benchmarks."
-                             "(this is not the same as using the 'current' environment!)")
+                        help="Do not modify environments, just execute benchmarks there."
+                             "(Envs must contain all required benchmark packages and their dependencies"
+                             "If benchmarks are not installed then use --clean False")
     parser.add_argument('--skip-package-listing', action='store_true', default=False,
                         help="Skip 'pip freeze' and 'conda list' steps")
     parser.add_argument('--benchmarks', '-b', default=None, nargs='+',
@@ -57,7 +58,7 @@ def main():
     args = parser.parse_args()
 
     print('###### Preparing environments... ######\n')
-    env_kwargs = dict(clobber=args.clean, skip_listing=args.skip_package_listing)
+    env_kwargs = dict(clobber=args.clean, skip_listing=args.skip_package_listing, existing_env=args.use_existing_env)
 
     envs = setup_environments(args.env_path, **env_kwargs)
 

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import time
+from copy import deepcopy
 
 import run
 
@@ -98,7 +99,7 @@ def main():
             progress_bench = 'benchmark "{}" ({}/{}) via {}'.format(bname, j+1, nbenches, progress_env)
             print('#### Running', progress_bench)
             # Run benchmark
-            apply_overrides = [o['override'] for o in overrides if (bname in o['override']['benchmark'] and env.name in o['override']['envs'])]
+            apply_overrides = [deepcopy(o['override']) for o in overrides if (bname in o['override']['benchmark'] and env.name in o['override']['envs'])]
             run.run_benchmark(env, f, run_id=args.run_id, commands=args.commands,
                           run_path=args.run_path, overrides=apply_overrides,
                           suite=bname, dry_run=args.dry_run, progress=progress_bench)

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -84,7 +84,7 @@ def main():
         progress_env = 'environment "{}" ({}/{})'.format(env.name, i+1, nenvs)
         print('##### Selected', progress_env)
 
-        # Get benchmark yamls
+        # Get all specified benchmark yamls
         if args.bench_path:
             benchmarks = glob.glob(os.path.join(os.path.abspath(args.bench_path), '*.yaml'))
         else:
@@ -94,6 +94,9 @@ def main():
         if args.benchmarks is not None:
             benchmarks = [b for b in benchmarks if
                     os.path.splitext(os.path.basename(b))[0] in args.benchmarks]
+        else:
+            # from the list of all available benchmarks pick ones which are installed in an environment
+            benchmarks = [b for b in benchmarks if os.path.splitext(os.path.basename(b))[0] in env.benchmarks]
 
         nbenches = len(benchmarks)
         for j, f in enumerate(benchmarks):

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -87,7 +87,7 @@ def main():
             benchmarks = glob.glob(os.path.join(env.prefix, 'benchmarks', '*.yaml'))
 
         # from the list of all available benchmarks pick ones which are installed in an environment
-        benchmarks = [b for b in benchmarks if os.path.splitext(os.path.basename(b))[0] in env.benchmarks]
+        # benchmarks = [b for b in benchmarks if os.path.splitext(os.path.basename(b))[0] in env.benchmarks]
 
         # The user might have required specific benchmarks
         if args.benchmarks is not None:

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -91,7 +91,12 @@ def main():
 
         # The user might have required specific benchmarks
         if args.benchmarks is not None:
-            benchmarks = set(benchmarks).intersection(args.benchmarks)
+            new_benchmarks = []
+            for benchmark in args.benchmarks:
+                for benchfile in benchmarks:
+                    if benchmark in benchfile:
+                        new_benchmarks.append(benchfile)
+            benchmarks = new_benchmarks
 
         nbenches = len(benchmarks)
         for j, f in enumerate(benchmarks):

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -87,7 +87,7 @@ def main():
             benchmarks = glob.glob(os.path.join(env.prefix, 'benchmarks', '*.yaml'))
 
         # from the list of all available benchmarks pick ones which are installed in an environment
-        # benchmarks = [b for b in benchmarks if os.path.splitext(os.path.basename(b))[0] in env.benchmarks]
+        benchmarks = [b for b in benchmarks if os.path.splitext(os.path.basename(b))[0] in env.benchmarks]
 
         # The user might have required specific benchmarks
         if args.benchmarks is not None:

--- a/bearysta/conda_run.py
+++ b/bearysta/conda_run.py
@@ -90,13 +90,12 @@ def main():
         else:
             benchmarks = glob.glob(os.path.join(env.prefix, 'benchmarks', '*.yaml'))
 
+        # from the list of all available benchmarks pick ones which are installed in an environment
+        benchmarks = [b for b in benchmarks if os.path.splitext(os.path.basename(b))[0] in env.benchmarks]
+
         # The user might have required specific benchmarks
         if args.benchmarks is not None:
-            benchmarks = [b for b in benchmarks if
-                    os.path.splitext(os.path.basename(b))[0] in args.benchmarks]
-        else:
-            # from the list of all available benchmarks pick ones which are installed in an environment
-            benchmarks = [b for b in benchmarks if os.path.splitext(os.path.basename(b))[0] in env.benchmarks]
+            benchmarks = set(benchmarks).intersection(args.benchmarks)
 
         nbenches = len(benchmarks)
         for j, f in enumerate(benchmarks):

--- a/bearysta/run.py
+++ b/bearysta/run.py
@@ -131,9 +131,6 @@ def run_benchmark(env, config, run_path='runs', run_id=None, commands=None,
             with open(output_prefix + meta_suff + '.meta', 'w') as fd:
                 yaml.dump(arg_run, fd)
 
-            # output conda packages
-            with open(f'{output_prefix}_{env.name}_packages.yml', 'w') as fd:
-                yaml.dump(env.packages, fd)
 
 
 class CurrentEnv:

--- a/bearysta/run.py
+++ b/bearysta/run.py
@@ -22,6 +22,13 @@ def run_benchmark(env, config, run_path='runs', run_id=None, commands=None,
         run_id = str(time.time())
     os.makedirs('{}/{}/{}/{}/'.format(run_path, run_id, suite, env.name), exist_ok=True)
 
+    # path prefix = folder for all files created here
+    path_prefix = '{}/{}/{}/{}'.format(run_path, run_id, suite, env.name)
+
+    # dump conda env packages into yaml
+    with open(f'{path_prefix}/{env.name}_packages.yml', 'w') as fd:
+        yaml.dump(env.packages, fd)
+
     with open(config) as f:
         bench = yaml.load(f)
 
@@ -91,8 +98,7 @@ def run_benchmark(env, config, run_path='runs', run_id=None, commands=None,
         for i, values in enumerate(itertools.product(*vals)):
             print('## Running combination {}/{} of {}' .format(i+1, product_length, progress_inside))
             # output to file
-            output_prefix = '{}/{}/{}/{}/{}_{}'.format(run_path, run_id, suite,
-                                                env.name, time.time(), endpoint)
+            output_prefix = '{}/{}_{}'.format(path_prefix, time.time(), endpoint)
             arg_run = dict(zip(keys, values))
             # a copy of visible variables
             args = arg_run.copy()


### PR DESCRIPTION
1. Till now if "--use-existing-env" option for conda-run.py is used then bearysta tries to find conda env prefix folder, activates it and tries to update benchmark conda packages inside. This does not work in an environment which does not have an access to conda channel with benchmark's packages. So in this PR benchmarks update is disabled if "--use-existing-env" option is set
2. '--bench-path' was used to specify a list of benchmark.yaml config files to read info from. In this PR this param is changed so it takes a folder name to read yaml files from. Bearysta finds all *.yaml files there.
3. '--overrides-path' was used to specify a list of overrides for benchmark.yaml configs. In this PR this param is changed so it takes a folder name to read yaml files from. Bearysta finds all *.yaml files there.
4. Till now Bearysta generated yaml file with a list of installed packages in a conda env for each individual benchmark's run. In this PR this yaml is generated only once.
5. overrides yaml slightly updated:
previously it was

        override:
            benchmark: blackscholes_bench_python
            envs: [intelpython3]
        variables:
            batch: [0, 1, 2, 3, 4, 5, 6, 7]
            steps: 3
            step_size: 1
        
        commands:
            blackscholes_python_thr:
            blackscholes_python_seq:

now 'variables', 'commands' (and so on) are nested objects for overrides like this:

    override:
        benchmark: blackscholes_bench_python
        envs: [intelpython3]
        variables:
            batch: [0, 1, 2, 3, 4, 5, 6, 7]
            steps: 3
            step_size: 1
    
        commands:
            blackscholes_python_thr:
            blackscholes_python_seq: